### PR TITLE
Add input cards for muon simulations

### DIFF
--- a/CTA-PROD4-LST.cfg
+++ b/CTA-PROD4-LST.cfg
@@ -1,0 +1,330 @@
+% Configuration file for a LST in Prod-4/5 (CTA-PROD4 setup).
+
+  echo
+  echo ************************************************************************
+#ifdef TELESCOPE
+  echo Configuration for large-size telescope $(TELESCOPE) in Prod-4/5.
+#else
+  echo Global configuration parameters for large-size telescopes in Prod-4/5.
+#endif
+  echo ************************************************************************
+  echo
+
+% Start with configuration items not specific for LST.
+
+#include <CTA-PROD4-site.cfg>
+#include <CTA-PROD4-common.cfg>
+#include <CTA-PROD4-pmt.cfg>
+
+% The remainder is specific for LST.
+
+% ------------------------- Optical parameters --------------------------
+
+optics_config_name = LST
+optics_config_version = 2020-04-29  % Latest change: again new reflectivity curve
+
+parabolic_dish      = 1        % Mirrors are on a parabolic dish.
+focal_length        = 2800     % Nominal focal length [cm]. Effective focal length is 2930.6 cm based on optical ray-tracing.
+effective_focal_length = 2930.565 % Only to be used for image analysis. No effect in simulation itself.
+mirror_focal_length = 0        % Adapted automatically unless specified in file (idea is to have three groups or sort)
+% mirror_focal_length = 2862   % If using a single fixed focal length for a genuine parabolic dish [cm]
+dish_shape_length   = 2800     % Same as nominal focal length for strictly parabolic design
+
+#ifdef PERFECT_DISH
+  % If all mirrors are just perfect:
+  mirror_list         = mirror_CTA-LST-v20141201-198.dat   % 388.38 m^2 projected
+  random_focal_length            = 0.
+
+  mirror_reflection_random_angle = 0.0
+  mirror_align_random_distance   = 0.0
+  mirror_align_random_horizontal = 0.0,0.,0.,0.
+  mirror_align_random_vertical   = 0.0,0.,0.,0.
+#else
+  % Better try to use a realistic configuration:
+# ifdef LST_MIRRORS_GROUPED
+   mirror_list         = mirror_CTA-LST-flen_grouped.dat   % Three groups of focal lengths (negative flen values! random flen still applies)
+   random_focal_length =  0,20    % Assume flat distribution with a maximum of +-20 cm deviation from the given focal length
+%  Alternative for older sim_telarray versions
+%   random_focal_length = 11.5     % = 40/sqrt(12.) Gaussian distribution of same r.m.s.
+# else
+#  if defined(CTA_SOUTH)
+    echo Using mirror list for CTA-South LSTs.
+    mirror_list         = mirror_CTA-S-LST_v2020-04-07.dat   % Based on CTA-North LST 2-4 average of individual facet focal lengths.
+#  elif ( defined(LST1_PROTOTYPE) || ( defined(CTA_NORTH) && TELESCOPE == 1 && undefined(LST2) && undefined(LST3) && undefined(LST4) ) || defined(LST1) )
+    echo Using mirror list for CTA-North LST-1.
+    mirror_list         = mirror_CTA-N-LST1_v2019-03-31.dat  % Individual focal lengths
+#  elif ( ( defined(CTA_NORTH) && TELESCOPE == 2 ) || defined(LST2) )
+    echo Using mirror list for CTA-North LST-2.
+    mirror_list         = mirror_CTA-N-LST2_v2020-04-07.dat  % Individual focal lengths
+#  elif ( ( defined(CTA_NORTH) && TELESCOPE == 3 ) || defined(LST3) )
+    echo Using mirror list for CTA-North LST-3.
+    mirror_list         = mirror_CTA-N-LST3_v2020-04-07.dat  % Individual focal lengths
+#  elif ( ( defined(CTA_NORTH) && TELESCOPE == 4 ) || defined(LST4) )
+    echo Using mirror list for CTA-North LST-4.
+    mirror_list         = mirror_CTA-N-LST4_v2020-04-07.dat  % Individual focal lengths
+#  else
+    echo Using mirror list for unknown LST.
+    mirror_list         = mirror_CTA-S-LST_v2020-04-07.dat   % Based on CTA-North LST 2-4 average of individual facet focal lengths.
+#  endif
+   random_focal_length =  0,0                               % without extra randomness.
+# endif
+
+%  mirror_reflection_random_angle = 0.0075 % [deg] based on 2-f measurements of single mirror segments.
+  mirror_reflection_random_angle = 0.0075,0.125,0.037 % [deg] with tail in distribution needed to match telescope cumulative PSF distribution
+  mirror_align_random_distance   = 0.0 % cm
+% Preliminary values, to be revised:
+%  mirror_align_random_horizontal = 0.0025,28.,0.0,0.0 % no zenith dependence due to active mirror control
+%  mirror_align_random_vertical   = 0.0025,28.,0.0,0.0 % no zenith dependence due to active mirror control
+% LST-1 cumulative PSF distribution reproduced with worse mirror alignment than initially assumed.
+% The tail in the distribution could be due to very poorly aligned mirrors but we only have
+% the second random reflection angle component to describe the PSF tail (12.5% with 0.037 deg.).
+  mirror_align_random_horizontal = 0.0039,28.,0.0,0.0 % no zenith dependence due to active mirror control
+  mirror_align_random_vertical   = 0.0039,28.,0.0,0.0 % no zenith dependence due to active mirror control
+#endif
+
+mirror_offset       = 93.25    % [cm] behind/below axes crossing (see redmine issue 35807)
+focus_offset        = 6.55     % 1./(1./2800.-1./12.e5)-2800. (focusing at 12 km distance), starlight focusing target to pixel entrance
+
+% mirror_reflectivity = ref_SANKO_29ave.dat % Updated prod-3 reflectivity (Masaaki et. al.)
+% mirror_reflectivity = ref_200_1100_180314_ver2.1a.dat % Koji Noda, 2018-03-15
+% mirror_reflectivity = ref_200_1100_190211a.dat % Revised version 2019-02-18, with better absolute calibration.
+% mirror_reflectivity = ref_LST_2020-04-21.dat  % Revised version received 2020-04-21.
+mirror_reflectivity = ref_LST_2020-04-23.dat  % Revised version received 2020-04-23.
+
+% Accuracy of the tracking and measurement of current direction.
+% Pointing errors can always be mimicked at the analysis level:
+telescope_random_angle         = 0.
+telescope_random_error         = 0.
+
+% -------------------------- Camera ------------------------------
+
+camera_config_name = LST
+camera_config_version = 2020-06-28
+
+% The telescope_transmission factor corrects for the shadowing by
+% elements not explicitly included in sim_telarray. 
+% It is thus the ratio of the effective optical area (in projection) based on a
+% detailed ray-tracing with all elements over the same area in simplified
+% ray-tracing by sim_telarray.
+% The original evaluation by detailed ray-tracing (K.Noda, 2013, with ROBAST)
+% resulted in an un-projected non-shadowed mirror area of 369.14+-0.08 m^2, from
+% which after projection 365.2+-0.1 m^2 are expected. Re-evaluation in Dec. 2017
+% resulted in 365.4 m^2 projected. All on-axis.
+% Evaluation with sim_telarray results in 380.37+-0.07 m^2 with the 300 cm square
+% camera body and 377.71+-0.07 m^2 with the 348 cm square camera body assumption
+% including the mounting frame.
+
+% With obsolete 300 cm camera body value:
+% camera_body_shape = 2        % Square camera body, needs newer sim_telarray
+% camera_body_diameter = 300   % cm (only for shadowing, 3 m * 3 m square), obsolete since now including frame
+% telescope_transmission = 0.9622  % = 366.0/380.37 with 300 cm camera body accounted for explicitely.
+
+% Now using bigger camera body value (including mounting frame) by default.
+camera_body_shape = 2        % Square camera body, needs newer sim_telarray
+camera_body_diameter = 348   % cm (only for shadowing, includes mounting frame)
+telescope_transmission = 0.9690 % = 366.0/377.71 with 348 cm camera body + frame accounted for explicitely.
+
+camera_transmission = 1.0 % All of the transmission is now included in the camera_filter file.
+% camera_filter = Aclylite8_tra_v2013ref.dat % was used in prod3
+camera_filter = transmission_lst_window_No7-10_ave.dat % same as No7-10_ave.dat but not percent (and with 1000 nm extrapol.)
+
+% camera_config_file = camera_CTA-LST_analogsum21.dat
+% camera_config_file = camera_CTA-LST_analogsum21_v2019-03-01.dat % Pixel order resorted to 'spiral' module order convention.
+% quantum_efficiency = qe_R11920-100-02.dat % Similar to qe_R12992-100-05.dat but different batch.
+#if defined(LST1_PROTOTYPE) || ( defined(CTA_NORTH) && defined(LST1) )
+  % Like v2019-03-01 but lower QE pixels on the LST-1 camera edge, plus new and wider funnel efficiency table.
+  camera_config_file = camera_CTA-LST-1_analogsum21_v2020-04-14.dat 
+  quantum_efficiency = qe_lst1_20200318_high+low.dat % Only column for high QE pixels is active
+  pm_gain_index = 4.50     % (+- 0.30) For 8-dynode PMTs with first dynode stabilized at 350 V.
+  pm_transit_time = 24.74,9.0,350.,1066. % full and first dynode transit times at nominal voltage (8-dynode variant)
+  pm_voltage_variation = 0.041 % random voltage variation at given gain (44.2/1065.5)
+#else
+  % Like v2019-03-01 but lower QE pixels on the LST-2/3/4 camera edge, plus new and wider funnel efficiency table.
+  camera_config_file = camera_CTA-LST-234_analogsum21_v2020-04-14.dat 
+  quantum_efficiency = qe_lst2-4_20200318_high+low.dat % Only column for high QE pixels is active
+  pm_gain_index = 3.92     % (+- 0.11) For 7-dynode PMTs with first dynode stabilized at 350 V.
+  pm_transit_time = 20.89,9.0,350.,1135. % full and first dynode transit times at nominal voltage (7-dynode variant)
+  pm_voltage_variation = 0.03 % random voltage variation at given gain (33./1136., no difference between low and high QE)
+#endif
+qe_variation = 0.03  % variation beyond the sorting into high-QE and low-QE groups.
+gain_variation = 0.0187 % random gain variation after flatfielding adjustment (as in 1.87% rms of flatfielded HG signal)
+fadc_var_sensitivity = 0.01416 % increasing flatfielded LG signal relative r.m.s. to 2.74%.
+
+#define ONLY_ANALOG_SUM 1
+#define NO_MAJORITY 1
+#define NO_DIGITAL_SUM 1
+
+camera_pixels        = 1855  % needs to be specified explicitly
+
+min_photons = 300            % With fewer photons don't waste CPU time.
+min_photoelectrons = 25      % 50% efficiency at 70 p.e.
+store_photoelectrons = 20    % Save individual photo-electrons
+#ifdef LST_EXTREME_TRIGGER
+  min_photons = 220            % With fewer photons don't waste CPU time.
+  min_photoelectrons = 18      % 50% efficiency at 60 p.e.
+  store_photoelectrons = 16    % Save individual photo-electrons
+#endif
+
+% NSB scaled from 0.100 for HESS with geometrical factor 
+%   (386.9/106.4) * (4.9/4.1)**2 * (15.0/28.0)**2 = 1.491
+% and spectral factor (including shadowing factor)
+%   % 127.602/84.386 = 1.512 % Prod-2: Al(SiO2HfO2) coated mirrors, plexiglass window, HESS-like funnels, early R11920 PMTs.
+%   180.916/84.386 = 2.144 % Prod-3: ref_SANKO_29ave.dat coated mirrors, Acrylite window, optimized funnels, latest R11920 PMTs
+% bin/testeff -fqe qe_R11920-100-02.dat -fref ref_SANKO_29ave.dat -flen 28 \
+%   -fmir mirror_CTA-LST-v20141201-198.dat -fang CTA-LST_lightguide_eff.dat \
+%   -camtrans 1.0 -fflt Aclylite8_tra_v2013ref.dat -teltrans 0.954 200 550 260 1 20
+
+% nightsky_background = all:0.3171 % From prod-3 evaluation (via HESS-1 rate)
+% nightsky_background = all:0.2882 % Re-evaluation with Benn&Ellison spectrum: 0.262 ph./(cm^2 ns sr)
+% nightsky_background = all:0.2627 % For reference NSB intensity: 0.24 ph./(cm^2 ns sr)
+% nightsky_background = all:0.2650 % With new filter and reflectivity curves, for reference NSB.
+% NSB pixel p.e. rate calculation now based on high-QE curve. Rate of outer pixels with lower QE
+% is automatically reduced according to the QE scaling factor in the camera configuration file.
+#if ( defined(LST1_PROTOTYPE) || ( defined(CTA_NORTH) && TELESCOPE == 1 && undefined(LST2) && undefined(LST3) && undefined(LST4) ) || defined(LST1) )
+   nightsky_background = all:0.24586 % NSB of LST-1 prototype is a bit lower than others due to a different QE curve. For reference NSB.
+# ifdef HALFMOON
+   echo Configuring for sky illuminated by half moon in LST prototype.
+   nightsky_background = all:1.19690     % LST prototype: half moon
+# endif
+#else
+   nightsky_background = all:0.25307 % NSB of other LSTs derived from LST-2/4 (high-) QE curve. For reference NSB.
+# ifdef HALFMOON
+   echo Configuring for sky illuminated by half moon in LST.
+   nightsky_background = all:1.22981     % LST: half moon has 4.86x dark.
+# endif
+#endif
+
+% --------------- Placing of signals in simulated windows ---------------
+
+% We need to shift the pulses further 'right' in the simulated time windows,
+% such that the occasional early signals (at large core distance) are better covered.
+photon_delay = 19    % ns
+
+% --------------------------- Trigger -----------------------------------
+
+% The trigger simulation is over a slightly earlier window than the ADC signals (from interval -3 to 64 in ADC frame).
+disc_bins = 68  % Number of time intervals simulated for trigger.
+disc_start = 3  % How many intervals the trigger simulation starts before the ADC.
+
+% The camera config file has majority, analog sum, plus digital sum.
+#ifndef NO_ANALOG_SUM
+# define ANALOG_SUM 1
+#endif
+
+% Majority & analog sum input pulses:
+% discriminator_pulse_shape=pulse_CTA-Fx.dat % 2.9 ns FWHM + 300 MHz bandwidth -> 3.1 ns FWHM, used 2012 to 2020.
+% The high-gain input for the digitized signal is also considered a good approximation
+% for the trigger channel input pulse shape (G.M.Botella, Suda Yusuke, 2020-02-20):
+discriminator_pulse_shape = pulse_LST_8dynode_pix6_20200204.dat % data by Y. Kobayashi (ICRR), 2020-02-19.
+discriminator_amplitude = 6.5 % (was 20.) % mV for mean p.e. amplitude
+
+% Discriminator threshold (and corresponding multiplicity for telescope trigger):
+trigger_pixels = 3             % This means actually a level of 2.5 pixels. Not used for analog sum.
+discriminator_threshold = 99999
+
+% Telescope trigger (specified even if no majority trigger is used):
+default_trigger = AnalogSum
+teltrig_min_time                       0.5 % ns
+teltrig_min_sigsum                     7.8 % pV.s
+
+% With a single trigger type no delay compensation between trigger types needed.
+% Could be used though for systematic differences between telescope types.
+trigger_delay_compensation = all: 0 
+
+asum_threshold = 270.  % Aggressive trigger (limit at 2x dark)
+asum_clipping = 9999   % Effectively no clipping used any more.
+#ifdef HALFMOON
+  asum_threshold = 355.  % Aggressive trigger (limit at partial moon)
+#endif
+
+#ifdef THRESHOLD_5X
+  asum_threshold = 360.  % Aggressive trigger (limit at 5x dark, ~partial moon)
+  trigger_current_limit = 2000.0 % [microAmps] 
+  nsb_scaling_factor = 5 
+  Error No threshold value yet for 5x dark NSB level
+#endif
+#ifdef THRESHOLD_7X
+  asum_threshold = 400.  % Aggressive trigger (limit at 7x dark)
+  trigger_current_limit = 2000.0 % [microAmps] 
+  nsb_scaling_factor = 5 % Yes simulation is actually at 5x dark NSB.
+  Error No threshold value yet for up to 7x dark NSB level
+#endif
+#ifdef THRESHOLD_30X
+  trigger_current_limit = 2000.0 % [microAmps] 
+  nsb_scaling_factor = 30
+  min_photons = 100000000  % Bypass processing this telescope as early as possible
+  Echo Effectively disabled at 30x dark NSB.
+#endif
+
+asum_shaping_file = none % No further shaping needed - pulse is wide enough.
+asum_offset = 0.0
+
+#ifdef LST_SAFE_TRIGGER
+  asum_threshold = 296 % mV, resulting in 8 kHz accidental single rate (NSB rate ~ CR single rate) at twice "dark" NSB.
+  asum_clipping = 9999 % mV (effectively no clipping)
+  % No high-NSB threshold values known for safe trigger mode
+#endif
+#ifdef LST_EXTREME_TRIGGER
+  asum_threshold = 230 % mV, extreme threshold: stereo (2/4 tel.) NSB random rate at 1x dark = 0.1 * CR stereo (2/4), single rate is about 40 kHz (unstable!!)
+  asum_clipping = 9999 % mV (effectively no clipping)
+  % No high-NSB threshold values known for extreme trigger mode
+#endif
+
+% only_triggered_arrays=0
+only_triggered_telescopes=1
+
+% ------------------------------ Readout --------------------------------
+
+% Sampling rate in MHz:
+fadc_MHz = 1024 % MHz sampling rate
+
+% fadc_pulse_shape = pulse_CTA-Fx3.dat % Fast pulse shape with tail
+fadc_pulse_shape = pulse_LST_8dynode_pix6_20200204.dat % data by Y. Kobayashi (ICRR), 2020-02-19.
+
+% Read-out of a 40 ns window (within simulated 55 ns) following the actual trigger:
+fadc_bins = 75       % Number of time intervals simulated for ADC (extends by 10 ns beyond the 68 ns discriminator simulation)
+fadc_sum_bins = 40   % Number of ADC time intervals actually summed up or written as trace.
+fadc_sum_offset = 9  % How many intervals summation starts before telescope trigger.
+
+fadc_pedestal = 246          % Per time slice (positive signals only: unsigned!)
+fadc_err_pedestal = 0.5      % The reported pedestal differs from what gets internal used.
+fadc_var_pedestal = 30.      % Channel-to-channel r.m.s. differences.
+fadc_amplitude = 25.0        % The peak amplitude in a time slice for high gain.
+% fadc_noise = 6.33            % Derived from 6 samples integration window for white-noise assumption.
+fadc_noise = 6.7             % Derived from 6 samples integration window for white-noise assumption. (?)
+
+num_gains = 2                % Make it clear that we want to use two gains
+fadc_lg_pedestal = 207       % Per time slice (positive signals only: unsigned!)
+fadc_lg_err_pedestal = 0.3   % The reported pedestal differs from what gets internal used.
+fadc_lg_var_pedestal = 31.   % Channel-to-channel r.m.s. differences.
+fadc_lg_amplitude = 1.28     % The peak amplitude in a time slice for low gain (HG/LG=19.5, according to Seiya Nozaki)
+% fadc_lg_noise = 5.34         % Derived from 6 samples integration window for white-noise assumption.
+fadc_lg_noise = 5.7          % Derived from 6 samples integration window for white-noise assumption. (?)
+
+fadc_max_signal = 4095       % 12-bit ADC (applies to both channels unless specified)
+fadc_max_sum = 16777215      % 24-bit sum is unlimited for all practical purposes.
+
+#ifndef NO_PROCESSED_PEDESTALS
+% The camera server is supposed to not only fix up capacitor-by-capacitor raw-level calibration
+% but likely also applying a uniform computed pedestal.
+% Consequences of that on the overflow values are not clear yet.
+fadc_pedestal = 400.
+fadc_lg_pedestal = 400.
+fadc_var_pedestal = 0.4      % All pedestals equal within +-0.5 counts plus some error in evaluating it.
+fadc_lg_var_pedestal = 0.4
+fadc_max_signal = 4249       % 4095 + 400 - 246 for the processed ("pre-calibrated") high-gain traces, average
+fadc_lg_max_signal = 4288    % 4095 + 400 - 207 for the processed ("pre-calibrated") low-gain traces, average
+#endif
+
+% ----------------------------- Analysis --------------------------------
+
+% Pulse shape analysis with pulse sum around global peak
+% position only for significant pixels.
+pulse_analysis = -30
+
+% Pulse analysis provides a conditional 8 ns integration at 1000 MHz sampling rate.
+sum_before_peak = 3
+sum_after_peak = 4
+
+tailcut_scale = 2.6 % For built-in image cleaning (not relevant for later analysis)
+

--- a/INPUTS_CTA_PROD5-LaPalma-baseline-muon-single-template-0deg_suda
+++ b/INPUTS_CTA_PROD5-LaPalma-baseline-muon-single-template-0deg_suda
@@ -1,0 +1,231 @@
+* CORSIKA inputs file template for Prod-5 CTA North (La Palma) simulations at 20 deg zenith angle.
+* Includes a baseline-type array layouts (of 4 LSTs plus 15 MSTs, the latter with two camera types).
+* Includes alternatives for different primaries (selected by pre-processor),
+* for PRMPAR, ERANGE, VIEWCONE, CSCAT parameters.
+* Includes site definitions for La Palma only, with telescope positions along slope of mountain.
+* Showers can come from North (default), South, East, or West.
+* Number of showers to be simulated needs to be adapted to run duration for each primary type.
+* SEEDs need to be re-generated for each simulation run separately!!!
+*
+* =============== Corsika INPUTS =======================
+*
+* [ Job parameters ]
+*
+RUNNR   1                               // Number of run, to be auto-numbered by job submission
+EVTNR   1                               // Number of first shower event (usually 1)
+*
+* [ Random number generator: 4 sequences used in IACT mode ]
+*
+SEED   385928125   401   0              // Seed for 1st random number sequence, to be re-generated
+SEED   827619802   859   0              // Seed for 2nd random number sequence, to be re-generated
+SEED   195989238   390   0              // Seed for 3rd random number sequence, to be re-generated
+SEED   539053819   323   0              // Seed for 4th random number sequence, to be re-generated
+*
+* [ Primary particle options ]
+*
+PRMPAR  6             // mu-
+#ifdef PRMPAR
+PRMPAR $(PRMPAR)
+#endif
+*
+#ifndef ONAXIS
+#define DIFFUSE 1
+#endif
+* ERANGE  5.832 1E3     // Energy range of primary particle (in GeV): muons with 50% opening angle or more
+ERANGE  8.418 1E3     // Energy range of primary particle (in GeV): muons with 80% opening angle or more
+#ifdef EMIN
+# ifdef EMAX
+ERANGE   $(EMIN)E3 $(EMAX)E3 // Requires EMIN and EMAX in units of TeV.
+# endif
+#endif
+*
+ESLOPE  -2.0          // Slope of primary energy spectrum (-2.0 is equal CPU time per decade)
+#ifdef ESLOPE
+ESLOPE $(ESLOPE)             // Requires spectral slope ESLOPE (<0)
+#endif
+*
+NSHOW   1000                         // number of showers to generate
+#ifdef NSHOW
+NSHOW    $(NSHOW)            // Requires NSHOW environment variable.
+#endif
+*
+THETAP  0.  0.      // Range of zenith angles (degrees)
+#ifdef ZENITH_ANGLE
+THETAP  $(ZENITH_ANGLE) $(ZENITH_ANGLE)      // Range of zenith angles (degrees)
+#endif
+*
+PHIP   180. 180.      // Range of azimuth angles (degree): primaries coming from North
+#ifdef FROM_SOUTH
+PHIP    0. 0.         // Range of azimuth angles (degree): primaries coming from South
+#else
+# ifdef FROM_EAST
+PHIP    90. 90.       // Range of azimuth angles (degree): primaries coming from East
+# else
+#  ifdef FROM_WEST
+PHIP   270. 270.      // Range of azimuth angles (degree): primaries coming from West
+#  else
+PHIP   180. 180.      // Range of azimuth angles (degree): primaries coming from North
+#  endif
+# endif
+#endif
+
+#if defined(ALIGN_B_FIELD)
+* Geomagnetic field is assumed to be aligned with geographic North (array x axis).
+# define AZM_FROM_SOUTH 0.
+# define AZM_FROM_EAST  90.
+# define AZM_FROM_NORTH 180.
+# define AZM_FROM_WEST  270.
+#else
+* Geomagnetic field aligned as predicted for year 2020.0.
+# define AZM_FROM_SOUTH -5.3195
+# define AZM_FROM_EAST  84.6805
+# define AZM_FROM_NORTH 174.6805
+# define AZM_FROM_WEST  264.6805
+#endif
+
+#if defined(FROM_SOUTH)
+PHIP $(AZM_FROM_SOUTH) $(AZM_FROM_SOUTH)  // CORSIKA azimuth angles (degree) for primaries coming from South.
+IACT setenv AZM 180     // Corresponding astronomical azimuth, from geographical North towards East.
+#elif defined(FROM_EAST)
+PHIP $(AZM_FROM_EAST) $(AZM_FROM_EAST)  // CORSIKA azimuth angles (degree) for primaries coming from East.
+IACT setenv AZM 90      // Corresponding astronomical azimuth, from geographical North towards East.
+#elif defined(FROM_WEST)
+PHIP $(AZM_FROM_WEST) $(AZM_FROM_WEST) // CORSIKA azimuth angles (degree) for primaries coming from West.
+IACT setenv AZM 270     // Corresponding astronomical azimuth, from geographical North towards East.
+#else
+PHIP $(AZM_FROM_NORTH) $(AZM_FROM_NORTH) // CORSIKA azimuth angles (degree) for primaries coming from North.
+IACT setenv AZM 0       // Corresponding astronomical azimuth, from geographical North towards East.
+#endif
+
+*# ifdef TEL_LST
+* VIEWCONE 0. 2.0     // Such that at half of maximum Cherenkov angle the ring still fits into FoV. (LST: actual FoV-diam=4.6 deg)
+* VIEWCONE 0. 1.1     // Such that at maximum Cherenkov angle the ring still fits into FoV. (LST: actual FoV-diam=4.6 deg)
+VIEWCONE 0. 0.9     // Such that at maximum Cherenkov angle the ring still fits into FoV. (LST: required FoV-diam=4.2 deg)
+*# endif
+*
+*  Optionally override prepared demo run settings
+*
+#ifdef NSHOW
+NSHOW    $(NSHOW)            // Requires NSHOW environment variable.
+#endif
+#if defined(EMIN) && defined(EMAX)
+ERANGE   $(EMIN)E3 $(EMAX)E3 // Requires EMIN and EMAX in units of TeV.
+#endif
+*
+* [ Site specific options ]
+*
+* For Prod5 the site parameters are basically as in prod-3b except the atmospheric profile
+* (and in the telescope simulation also the atmospheric extinction).
+* The geographical coordinates of the La Palma site candidate are:
+* 28.762166097 deg North, 17.892030200 deg West, altitude: 2158 to 2242 m altitude m a.s.l. 
+* at the foundation level (center at 2180 m, observation level at 2158 m).
+*
+FIXCHI 580.
+OBSLEV 2158.E2      // Observation level (in cm) for lowest telescope
+ATMOSPHERE 36 Y     // Should be slightly better for La Palma than profiles 1 (tropical)
+*
+* ./geomag70 IGRF12.COF 2020.00 D K2.180 28.7621661 -17.8920302
+* 
+MAGNET 30.576 23.571    // La Palma, 2020.0
+ARRANG $(AZM_FROM_SOUTH)          // La Palma, 2020.0
+* 
+*  Geomag v7.0 - Jan 25, 2010 
+* 
+* 
+*   Model: IGRF2015 
+*   Latitude: 28.76 deg
+*   Longitude: -17.89 deg
+*   Altitude: 2.18 km
+*   Date of Interest:  2020.00
+* 
+*  -------------------------------------------------------------------------------
+*    Date          D           I           H        X        Y        Z        F
+*    (yr)      (deg min)   (deg min)     (nT)     (nT)     (nT)     (nT)     (nT)
+*   2020.00    -5d  19m    37d  31m   30707.8  30575.5  -2846.9  23570.7  38711.0
+*  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*    Date         dD          dI           dH       dX       dY       dZ       dF
+*    (yr)      (min/yr)    (min/yr)    (nT/yr)  (nT/yr)  (nT/yr)  (nT/yr)  (nT/yr)
+*   2020.00       7.2       -4.7         34.3     40.0     61.1    -40.4      2.6
+*  -------------------------------------------------------------------------------
+* 
+* [ Core range ]
+*
+#if defined(NSCAT) && defined(CSCAT)
+CSCAT    $(NSCAT) $(CSCAT)E2 0. // Requires NSCAT (10/20) and CSCAT (in units of meters).
+#elif defined(DIFFUSE)
+CSCAT  20  1900E2  0. // Use shower several times (protons+electrons+..., larger area for diffuse origin)
+#else
+CSCAT  10  1400E2  0. // Use shower several times (gammas, point source only)
+#endif
+*
+* [ Telescope positions, for IACT option ] 
+* (Note: telescope z positions are Altitude - 2158 m + height of reflector)
+* ((With the lowest positions from prod-3 now dropped we changed the observation
+*   level from 2147 to 2158 m and lowered all telescope z coordinates by 11 m.))
+*
+* ----------------------- New telescope coordinates derived from INFRA-provided UTM values ---------------------------
+*                         (re-centered on new central MST (MST 15) position).
+*
+* LSTs:
+*
+#define LSTHT  16.00E2
+#define LSTRAD 12.50E2
+* 
+TELESCOPE    0.0E2    0.0E2  $(LSTHT)    $(LSTRAD)  # LST
+* CSCAT  1  12.3E2  0.  # Just beyond dish
+* CSCAT  1  11E2  0.    # Close to edge of dish
+CSCAT  1  9.8E2  0.     # To 80% of dish radius
+#ifdef NSCAT
+# ifdef CSCAT
+CSCAT    $(NSCAT) $(CSCAT)E2 0. // Requires NSCAT (1/10/20) and CSCAT (in units of meters).
+# endif
+#endif
+*
+* [Interaction flags]
+*
+FIXHEI  0.  0          // First interaction height & target (0. 0 for random)
+* FIXCHI  0.             // Starting altitude (g/cm**2). 0. is at boundary to space.
+TSTART  T              // Needed for emission and scattering of primary
+ECUTS   0.3  0.1  0.020  0.020         // Energy cuts for particles
+MUADDI  F                              // Additional info for muons not needed
+MUMULT  T                              // Muon multiple scattering angle
+LONGI   T  20.  F  F                   // Longit.distr. & step size & fit
+MAXPRT  0                              // Max. number of printed events
+ECTMAP  1.E6                           // Cut on gamma factor for printout
+STEPFC  1.0                            // Mult. scattering step length factor
+*
+* [ Cherenkov emission parameters ]
+*
+CERSIZ  5.         // Not above 10 for super/ultra-bialkali QE; 7 is fairly OK; 5 should be safe.
+CERFIL  F                              // No old-style Cherenkov output to extra file
+CWAVLG  230.  900.                     // Cherenkov wavelength band
+*
+* [ Debugging and output options ]
+*
+DEBUG   F  6  F  1000000               // Debug flag and logical unit for output
+DATBAS yes                             // Write a file with parameters used
+DIRECT  /dev/null                      // /dev/null means no normal CORSIKA data written
+#ifdef WITHOUT_MULTIPIPE
+# ifdef STRICT_BASELINE
+* TELFIL cta-prod5-lapalma-baseline.corsika.gz       // If telescope simulation not done directly in pipe
+TELFIL run${RUNNR}_${PRMNAME}_za${ZA}deg_azm${AZM}deg-lapalma-baseline${extra_suffix2}.corsika.zst
+# else
+TELFIL run${RUNNR}_${PRMNAME}_za${ZA}deg_azm${AZM}deg-lapalma${extra_suffix2}.corsika.zst
+# endif
+#else
+*TELFIL |${SIM_TELARRAY_PATH}/run_sim_cta     // Telescope photon bunch output (eventio format)
+TELFIL run${RUNNR}_muon.corsika.gz
+IACT TELOPT -c cta-prod5-lapalma-baseline
+#endif
+IACT PRINT_EVENTS 100 100 1
+*
+* [ IACT tuning parameters ]
+*
+IACT SPLIT_AUTO 8M                     // Split data with more than 8 million bunches
+IACT IO_BUFFER 800MB                  // At 32 bytes per bunch this could be up to 500 MB
+IACT MAX_BUNCHES 1000000               // Let photon bunch thinning set in earlier.
+*
+* [ This is the end, my friend ]
+*
+EXIT                                   // terminates input
+* ========================================================


### PR DESCRIPTION
Following the discussion with @YusukeSuda, who produced the latest muon simulations, this is the addition of the corsika/simtel files for muon production that were used for that. 
I created a separate branch to contain them, but it may as well be that the best way to store them is to give them a sensible name and add them to the corsika/simtel branches, let's hear opinions.