### PR TITLE
Add muon config

### DIFF
--- a/config_LST1_muons.cfg
+++ b/config_LST1_muons.cfg
@@ -1,0 +1,231 @@
+* CORSIKA inputs file template for Prod-5 CTA North (La Palma) simulations at 20 deg zenith angle.
+* Includes a baseline-type array layouts (of 4 LSTs plus 15 MSTs, the latter with two camera types).
+* Includes alternatives for different primaries (selected by pre-processor),
+* for PRMPAR, ERANGE, VIEWCONE, CSCAT parameters.
+* Includes site definitions for La Palma only, with telescope positions along slope of mountain.
+* Showers can come from North (default), South, East, or West.
+* Number of showers to be simulated needs to be adapted to run duration for each primary type.
+* SEEDs need to be re-generated for each simulation run separately!!!
+*
+* =============== Corsika INPUTS =======================
+*
+* [ Job parameters ]
+*
+RUNNR   1                               // Number of run, to be auto-numbered by job submission
+EVTNR   1                               // Number of first shower event (usually 1)
+*
+* [ Random number generator: 4 sequences used in IACT mode ]
+*
+SEED   385928125   401   0              // Seed for 1st random number sequence, to be re-generated
+SEED   827619802   859   0              // Seed for 2nd random number sequence, to be re-generated
+SEED   195989238   390   0              // Seed for 3rd random number sequence, to be re-generated
+SEED   539053819   323   0              // Seed for 4th random number sequence, to be re-generated
+*
+* [ Primary particle options ]
+*
+PRMPAR  6             // mu-
+#ifdef PRMPAR
+PRMPAR $(PRMPAR)
+#endif
+*
+#ifndef ONAXIS
+#define DIFFUSE 1
+#endif
+* ERANGE  5.832 1E3     // Energy range of primary particle (in GeV): muons with 50% opening angle or more
+ERANGE  8.418 1E3     // Energy range of primary particle (in GeV): muons with 80% opening angle or more
+#ifdef EMIN
+# ifdef EMAX
+ERANGE   $(EMIN)E3 $(EMAX)E3 // Requires EMIN and EMAX in units of TeV.
+# endif
+#endif
+*
+ESLOPE  -2.0          // Slope of primary energy spectrum (-2.0 is equal CPU time per decade)
+#ifdef ESLOPE
+ESLOPE $(ESLOPE)             // Requires spectral slope ESLOPE (<0)
+#endif
+*
+NSHOW   1000                         // number of showers to generate
+#ifdef NSHOW
+NSHOW    $(NSHOW)            // Requires NSHOW environment variable.
+#endif
+*
+THETAP  0.  0.      // Range of zenith angles (degrees)
+#ifdef ZENITH_ANGLE
+THETAP  $(ZENITH_ANGLE) $(ZENITH_ANGLE)      // Range of zenith angles (degrees)
+#endif
+*
+PHIP   180. 180.      // Range of azimuth angles (degree): primaries coming from North
+#ifdef FROM_SOUTH
+PHIP    0. 0.         // Range of azimuth angles (degree): primaries coming from South
+#else
+# ifdef FROM_EAST
+PHIP    90. 90.       // Range of azimuth angles (degree): primaries coming from East
+# else
+#  ifdef FROM_WEST
+PHIP   270. 270.      // Range of azimuth angles (degree): primaries coming from West
+#  else
+PHIP   180. 180.      // Range of azimuth angles (degree): primaries coming from North
+#  endif
+# endif
+#endif
+
+#if defined(ALIGN_B_FIELD)
+* Geomagnetic field is assumed to be aligned with geographic North (array x axis).
+# define AZM_FROM_SOUTH 0.
+# define AZM_FROM_EAST  90.
+# define AZM_FROM_NORTH 180.
+# define AZM_FROM_WEST  270.
+#else
+* Geomagnetic field aligned as predicted for year 2020.0.
+# define AZM_FROM_SOUTH -5.3195
+# define AZM_FROM_EAST  84.6805
+# define AZM_FROM_NORTH 174.6805
+# define AZM_FROM_WEST  264.6805
+#endif
+
+#if defined(FROM_SOUTH)
+PHIP $(AZM_FROM_SOUTH) $(AZM_FROM_SOUTH)  // CORSIKA azimuth angles (degree) for primaries coming from South.
+IACT setenv AZM 180     // Corresponding astronomical azimuth, from geographical North towards East.
+#elif defined(FROM_EAST)
+PHIP $(AZM_FROM_EAST) $(AZM_FROM_EAST)  // CORSIKA azimuth angles (degree) for primaries coming from East.
+IACT setenv AZM 90      // Corresponding astronomical azimuth, from geographical North towards East.
+#elif defined(FROM_WEST)
+PHIP $(AZM_FROM_WEST) $(AZM_FROM_WEST) // CORSIKA azimuth angles (degree) for primaries coming from West.
+IACT setenv AZM 270     // Corresponding astronomical azimuth, from geographical North towards East.
+#else
+PHIP $(AZM_FROM_NORTH) $(AZM_FROM_NORTH) // CORSIKA azimuth angles (degree) for primaries coming from North.
+IACT setenv AZM 0       // Corresponding astronomical azimuth, from geographical North towards East.
+#endif
+
+*# ifdef TEL_LST
+* VIEWCONE 0. 2.0     // Such that at half of maximum Cherenkov angle the ring still fits into FoV. (LST: actual FoV-diam=4.6 deg)
+* VIEWCONE 0. 1.1     // Such that at maximum Cherenkov angle the ring still fits into FoV. (LST: actual FoV-diam=4.6 deg)
+VIEWCONE 0. 0.9     // Such that at maximum Cherenkov angle the ring still fits into FoV. (LST: required FoV-diam=4.2 deg)
+*# endif
+*
+*  Optionally override prepared demo run settings
+*
+#ifdef NSHOW
+NSHOW    $(NSHOW)            // Requires NSHOW environment variable.
+#endif
+#if defined(EMIN) && defined(EMAX)
+ERANGE   $(EMIN)E3 $(EMAX)E3 // Requires EMIN and EMAX in units of TeV.
+#endif
+*
+* [ Site specific options ]
+*
+* For Prod5 the site parameters are basically as in prod-3b except the atmospheric profile
+* (and in the telescope simulation also the atmospheric extinction).
+* The geographical coordinates of the La Palma site candidate are:
+* 28.762166097 deg North, 17.892030200 deg West, altitude: 2158 to 2242 m altitude m a.s.l. 
+* at the foundation level (center at 2180 m, observation level at 2158 m).
+*
+FIXCHI 580.
+OBSLEV 2158.E2      // Observation level (in cm) for lowest telescope
+ATMOSPHERE 99 Y     // Use a custom profile by filename (this must come _AFTER_ IACT ATMOFILE ...!)
+*
+* ./geomag70 IGRF12.COF 2020.00 D K2.180 28.7621661 -17.8920302
+* 
+MAGNET 30.576 23.571    // La Palma, 2020.0
+ARRANG $(AZM_FROM_SOUTH)          // La Palma, 2020.0
+* 
+*  Geomag v7.0 - Jan 25, 2010 
+* 
+* 
+*   Model: IGRF2015 
+*   Latitude: 28.76 deg
+*   Longitude: -17.89 deg
+*   Altitude: 2.18 km
+*   Date of Interest:  2020.00
+* 
+*  -------------------------------------------------------------------------------
+*    Date          D           I           H        X        Y        Z        F
+*    (yr)      (deg min)   (deg min)     (nT)     (nT)     (nT)     (nT)     (nT)
+*   2020.00    -5d  19m    37d  31m   30707.8  30575.5  -2846.9  23570.7  38711.0
+*  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*    Date         dD          dI           dH       dX       dY       dZ       dF
+*    (yr)      (min/yr)    (min/yr)    (nT/yr)  (nT/yr)  (nT/yr)  (nT/yr)  (nT/yr)
+*   2020.00       7.2       -4.7         34.3     40.0     61.1    -40.4      2.6
+*  -------------------------------------------------------------------------------
+* 
+* [ Core range ]
+*
+#if defined(NSCAT) && defined(CSCAT)
+CSCAT    $(NSCAT) $(CSCAT)E2 0. // Requires NSCAT (10/20) and CSCAT (in units of meters).
+#elif defined(DIFFUSE)
+CSCAT  20  1900E2  0. // Use shower several times (protons+electrons+..., larger area for diffuse origin)
+#else
+CSCAT  10  1400E2  0. // Use shower several times (gammas, point source only)
+#endif
+*
+* [ Telescope positions, for IACT option ] 
+* (Note: telescope z positions are Altitude - 2158 m + height of reflector)
+* ((With the lowest positions from prod-3 now dropped we changed the observation
+*   level from 2147 to 2158 m and lowered all telescope z coordinates by 11 m.))
+*
+* ----------------------- New telescope coordinates derived from INFRA-provided UTM values ---------------------------
+*                         (re-centered on new central MST (MST 15) position).
+*
+* LSTs:
+*
+#define LSTHT  16.00E2
+#define LSTRAD 12.50E2
+* 
+TELESCOPE    0.0E2    0.0E2  $(LSTHT)    $(LSTRAD)  # LST
+* CSCAT  1  12.3E2  0.  # Just beyond dish
+* CSCAT  1  11E2  0.    # Close to edge of dish
+CSCAT  1  9.8E2  0.     # To 80% of dish radius
+#ifdef NSCAT
+# ifdef CSCAT
+CSCAT    $(NSCAT) $(CSCAT)E2 0. // Requires NSCAT (1/10/20) and CSCAT (in units of meters).
+# endif
+#endif
+*
+* [Interaction flags]
+*
+FIXHEI  0.  0          // First interaction height & target (0. 0 for random)
+* FIXCHI  0.             // Starting altitude (g/cm**2). 0. is at boundary to space.
+TSTART  T              // Needed for emission and scattering of primary
+ECUTS   0.3  0.1  0.020  0.020         // Energy cuts for particles
+MUADDI  F                              // Additional info for muons not needed
+MUMULT  T                              // Muon multiple scattering angle
+LONGI   T  20.  F  F                   // Longit.distr. & step size & fit
+MAXPRT  0                              // Max. number of printed events
+ECTMAP  1.E6                           // Cut on gamma factor for printout
+STEPFC  1.0                            // Mult. scattering step length factor
+*
+* [ Cherenkov emission parameters ]
+*
+CERSIZ  5.         // Not above 10 for super/ultra-bialkali QE; 7 is fairly OK; 5 should be safe.
+CERFIL  F                              // No old-style Cherenkov output to extra file
+CWAVLG  230.  900.                     // Cherenkov wavelength band
+*
+* [ Debugging and output options ]
+*
+DEBUG   F  6  F  1000000               // Debug flag and logical unit for output
+DATBAS yes                             // Write a file with parameters used
+DIRECT  /dev/null                      // /dev/null means no normal CORSIKA data written
+#ifdef WITHOUT_MULTIPIPE
+# ifdef STRICT_BASELINE
+* TELFIL cta-prod5-lapalma-baseline.corsika.gz       // If telescope simulation not done directly in pipe
+TELFIL run${RUNNR}_${PRMNAME}_za${ZA}deg_azm${AZM}deg-lapalma-baseline${extra_suffix2}.corsika.zst
+# else
+TELFIL run${RUNNR}_${PRMNAME}_za${ZA}deg_azm${AZM}deg-lapalma${extra_suffix2}.corsika.zst
+# endif
+#else
+*TELFIL |${SIM_TELARRAY_PATH}/run_sim_cta     // Telescope photon bunch output (eventio format)
+TELFIL run${RUNNR}_muon.corsika.gz
+IACT TELOPT -c cta-prod5-lapalma-baseline
+#endif
+IACT PRINT_EVENTS 100 100 1
+*
+* [ IACT tuning parameters ]
+*
+IACT SPLIT_AUTO 8M                     // Split data with more than 8 million bunches
+IACT IO_BUFFER 800MB                  // At 32 bytes per bunch this could be up to 500 MB
+IACT MAX_BUNCHES 1000000               // Let photon bunch thinning set in earlier.
+*
+* [ This is the end, my friend ]
+*
+EXIT                                   // terminates input
+* ========================================================


### PR DESCRIPTION
Following #21 and after implementing the comments there, here is the corsika config for simulating muons. For the simtel one, we could directly use:
https://github.com/cta-observatory/lst-sim-config/blob/sim-telarray/CTA-PROD4-LST.cfg

keeping in mind that the `telescope_transmission` defined [here](https://github.com/cta-observatory/lst-sim-config/blob/59b93b4bb696b90c425b27e5d0082fc9f4f36540/CTA-PROD4-LST.cfg#L108) corresponds to 80% optical efficiency or make a new one with `telescope_transmission` configurable as @mexanick suggested.