### PR TITLE
removed part of the atmospheric transmission profile 

### DIFF
--- a/site.cfg
+++ b/site.cfg
@@ -4,22 +4,22 @@
 # define TELESCOPE 0
 #endif
 
-# define ATMOSPHERE_LA_PALMA
-# define CTA_SITE LaPalma
+#define ATMOSPHERE_LA_PALMA
+#define CTA_SITE LaPalma
 
 #if TELESCOPE == 0
 
 % The altitude level and the corresponding transmission are typically
 % configured on the command line. So this is more a reminder of what to expect:
 
-#ifndef SITE_ALTITUDE
+# ifndef SITE_ALTITUDE
 #  define SITE_ALTITUDE 2158
-#endif
-#ifndef SITE_NAME
+# endif
+# ifndef SITE_NAME
 #  define SITE_NAME LaPalma
-#endif
+# endif
   altitude = $(SITE_ALTITUDE) % m
-#if defined(LOW_EXTINCTION)
+# if defined(LOW_EXTINCTION)
     echo Using low-aerosol (very quiet sea) atmospheric transmission table for the site on La Palma.
     atmospheric_transmission = atm_trans_$(SITE_ALTITUDE)_1_3_2_0_0_0.1_0.1.dat
 # elif defined(NAVY_MARITIME)
@@ -28,19 +28,6 @@
 # else
     echo Warning: using desert atmospheric transmission table for the site on La Palma
     atmospheric_transmission = atm_trans_$(SITE_ALTITUDE)_1_10_0_0_$(SITE_ALTITUDE).dat
-#endif
+# endif
 
-% Instead of setting these two values on the command line, a
-% preprocessor definition could be used, either naming the site
-% or specifying the altitude (which implies the transmission file to use).
-
-  echo Manually setting the site altitude to $(SITE_ALTITUDE) m a.s.l. for site $(SITE_NAME)
-  altitude = $(SITE_ALTITUDE)
-#ifdef NAVY_MARITIME
-    echo Using navy maritime atmospheric transmission (boundary layer starting at sea level), site $(SITE_NAME).
-    atmospheric_transmission = atm_trans_$(SITE_ALTITUDE)_1_3_0_0_0.dat
-# else
-    echo Using navy maritime atmospheric transmission (boundary layer starting at $(SITE_ALTITUDE)), site $(SITE_NAME).
-    atmospheric_transmission = atm_trans_$(SITE_ALTITUDE)_1_10_0_0_$(SITE_ALTITUDE).dat
-#endif
 #endif


### PR DESCRIPTION
that was left by mistake from the original config(non paranal and non la palma)

also updated the number of spaces in the precompiler definitions to improve the visibility of conditions
those settings are only used for "TELESCOPE 0" hence likely they are either way  overwritten by the command line transmission file