### PR TITLE
Fix magic mirror degradation

### DIFF
--- a/MAGIC1.cfg
+++ b/MAGIC1.cfg
@@ -52,6 +52,8 @@ focus_offset        = 2.89     % 1./(1./1700.-1./10.e5) - 1700. (focusing at 10 
 mirror_reflectivity = ref_MAGIC1_average_20220201.dat % Recomputed average from MAGIC reflector
 telescope_transmission = 0.61  % camera "mirror fraction" for ST.03.16
 
+mirror_degraded_reflection = 1.0 % this is not used for MAGIC, so we need to reset it to the default value
+
 % Accuracy of the tracking and measurement of current direction.
 % Pointing errors can always be mimicked at the analysis level:
 telescope_random_angle         = 0.
@@ -66,7 +68,6 @@ camera_pixels        = 1039  % needs to be specified explicitly
 
 #include <pmt_MAGIC1_test.cfg>
 quantum_efficiency = qe-hamamatsu_MAGIC1_koji.dat % average curve from MAGIC camera 
-
 
 camera_transmission = 1.0 % All of the transmission is now included in the camera_filter file.
 % camera_filter = Aclylite8_tra_v2013ref.dat

--- a/MAGIC2.cfg
+++ b/MAGIC2.cfg
@@ -51,6 +51,8 @@ focus_offset        = 2.89     % 1./(1./1700.-1./10.e5) - 1700. (focusing at 10 
 mirror_reflectivity = ref_MAGIC2_average.dat % MAGIC reflector weighted average reflectivity
 telescope_transmission = 0.69  % camera "mirror fraction" for ST.03.16
 
+mirror_degraded_reflection = 1.0 % this is not used for MAGIC, so we need to reset it to the default value
+
 % Accuracy of the tracking and measurement of current direction.
 % Pointing errors can always be mimicked at the analysis level:
 telescope_random_angle         = 0.


### PR DESCRIPTION
this is not used for MAGIC simulation, but it is used for LST1, so if LST1 and MAGIC are simulated together it needs to be reset not to propagate the LST1 number
it should solve issue #34 

sorry for the typo in the branch name it should be fix_...