### PR TITLE
fixed some of the default parameters of MAGIC that were also overwritten by LST

### DIFF
--- a/MAGIC1.cfg
+++ b/MAGIC1.cfg
@@ -77,6 +77,7 @@ camera_filter = none
 
 % this is probably not used at all 
 camera_body_diameter = 200   % cm (only for shadowing)
+camera_body_shape = 2 % square
 
 min_photons = 100        
 min_photoelectrons = 15    % 25 phe is the default for LST, here using a bit smaller value not to lose small triggers
@@ -153,6 +154,10 @@ fadc_sum_offset = 10  % How many intervals summation starts before telescope tri
 fadc_pedestal = 300          % Per time slice (positive signals only: unsigned!)
 fadc_amplitude = 24.5        % The peak amplitude in a time slice for high gain.
 fadc_noise = 16.1            % Again per time slice (high gain).
+
+fadc_var_pedestal = 0.       % not simulated in MAGIC
+fadc_err_pedestal = 0.       % not simulated in MAGIC
+fadc_var_sensitivity = 0.    % not simulated in MAGIC
 
 num_gains = 1                % Make it clear that we want to use two gains
 % fadc_lg_pedestal = 300       % Per time slice (positive signals only: unsigned!)

--- a/MAGIC1.cfg
+++ b/MAGIC1.cfg
@@ -75,8 +75,7 @@ camera_transmission = 1.0 % All of the transmission is now included in the camer
 % hence to have direct translation of parameters from camera to sim_telarray we switch it off in here 
 camera_filter = none
 
-% this is probably not used at all 
-camera_body_diameter = 200   % cm (only for shadowing)
+camera_body_diameter = 0.   % the true size is ~200cm, but the shadowing is not taken into account in MagicSoft
 camera_body_shape = 2 % square
 
 min_photons = 100        

--- a/MAGIC1_laser.cfg
+++ b/MAGIC1_laser.cfg
@@ -1,0 +1,13 @@
+
+
+% MAGIC settings: calibration_run 355. 5. 195.00 1.1 0.2 2000
+%   lambda, sigma_lambda, phot_per_pix, fwhm_time, rms_pulsetime, nevents
+% wavelenth is fixed to 400 nm in sim_telarray, and there is no calibration-specific jitter
+laser_photons = 195
+laser_var_photons = 0.0 % not simulated in MAGIC
+laser_events = 2000
+laser_pulse_offset = 0. % to set it same as showers
+laser_pulse_exptime = 0. % disable
+laser_pulse_sigtime = 0.468 %  FWHM 1.1 ns / 2.35
+laser_external_trigger = 0 % probably not needed
+pedestal_events = 2000

--- a/MAGIC2.cfg
+++ b/MAGIC2.cfg
@@ -77,7 +77,7 @@ camera_filter = none
 
 % this is probably not used at all 
 camera_body_diameter = 200   % cm (only for shadowing)
-
+camera_body_shape = 2 % square
 
 min_photons = 100        
 min_photoelectrons = 15        % 25 phe is the default for LST, here using a bit smaller value not to lose small triggers
@@ -154,6 +154,10 @@ fadc_sum_offset = 10  % How many intervals summation starts before telescope tri
 fadc_pedestal = 300          % Per time slice (positive signals only: unsigned!)
 fadc_amplitude = 24.5        % The peak amplitude in a time slice for high gain.
 fadc_noise = 17.6            % Again per time slice (high gain).
+
+fadc_var_pedestal = 0.       % not simulated in MAGIC
+fadc_err_pedestal = 0.       % not simulated in MAGIC
+fadc_var_sensitivity = 0.    % not simulated in MAGIC
 
 num_gains = 1                % Make it clear that we want to use two gains
 % fadc_lg_pedestal = 300       % Per time slice (positive signals only: unsigned!)

--- a/MAGIC2.cfg
+++ b/MAGIC2.cfg
@@ -75,8 +75,7 @@ camera_transmission = 1.0 % All of the transmission is now included in the camer
 % hence to have direct translation of parameters from camera to sim_telarray we switch it off in here 
 camera_filter = none
 
-% this is probably not used at all 
-camera_body_diameter = 200   % cm (only for shadowing)
+camera_body_diameter = 0.   % the true size is ~200cm, but the shadowing is not taken into account in MagicSoft
 camera_body_shape = 2 % square
 
 min_photons = 100        

--- a/MAGIC2_laser.cfg
+++ b/MAGIC2_laser.cfg
@@ -1,0 +1,13 @@
+
+
+% MAGIC settings: calibration_run 355. 5. 195.00 1.1 0.2 2000
+%   lambda, sigma_lambda, phot_per_pix, fwhm_time, rms_pulsetime, nevents
+% wavelenth is fixed to 400 nm in sim_telarray, and there is no calibration-specific jitter
+laser_photons = 195
+laser_var_photons = 0.0 % not simulated in MAGIC
+laser_events = 2000
+laser_pulse_offset = 0. % to set it same as showers
+laser_pulse_exptime = 0. % disable
+laser_pulse_sigtime = 0.468 %  FWHM 1.1 ns / 2.35
+laser_external_trigger = 0 % probably not needed
+pedestal_events = 2000


### PR DESCRIPTION
the new values are actually different than both the default and the LST values.
The changed things are the camera shape (most probably not used at all, this is only used for ray tracing), pedestal variability and FADC gain variations (both things are not simulated in the standard MAGIC simulations)
Also added input cards for the calibration laser to simulate MAGIC-like flatfielding events (not enabled by default)