### PR TITLE
Trigger settings

### DIFF
--- a/LST1.cfg
+++ b/LST1.cfg
@@ -109,8 +109,8 @@ fadc_var_sensitivity = 0.01416                                        % increasi
 
 camera_pixels = 1855                                                    % needs to be specified explicitly
 
-min_photons = 300                                                       % With fewer photons don't waste CPU time.
-min_photoelectrons = 25                                                 % 50% efficiency at 70 p.e.
+min_photons = 120                                                       % With fewer photons don't waste CPU time.
+min_photoelectrons = 20                                                 % 50% efficiency at 70 p.e.
 store_photoelectrons = 20                                               % Save individual photo-electrons
 #ifdef LST_EXTREME_TRIGGER
   min_photons = 220                                                     % With fewer photons don't waste CPU time.
@@ -162,7 +162,7 @@ teltrig_min_sigsum = 7.8                                                % pV.s
 % Could be used though for systematic differences between telescope types.
 trigger_delay_compensation = all: 0
 
-asum_threshold = 270.                   % Aggressive trigger (limit at 2x dark)
+asum_threshold = 230.                   % Tuned to match the lowest-threshold available real LST1 data (intensity spectra) as of 20220408
 asum_clipping = 9999                    % Effectively no clipping used any more.
 #ifdef HALFMOON
   asum_threshold = 355.                 % Aggressive trigger (limit at partial moon)


### PR DESCRIPTION
The value  asum_threshold 270 mV is too high for much of the existing LST1 data. We reduce it to 230 mV, together with a reduction the min_photons and min_photoelectrons values settings to be on the safe side (but especially the change in min_photons will increase sim_telarray execution time - @Voutsi, did you check by how much?).