### PR TITLE
commenting out TSTART (needed for curved option) and making nscat a s…

### DIFF
--- a/config_LST1_2MAGIC_diffuse_gammas.cfg
+++ b/config_LST1_2MAGIC_diffuse_gammas.cfg
@@ -76,7 +76,7 @@ ARRANG -4.84             // La Palma, 01/12/2021
 * 
 * [ Core range ]
 *
-CSCAT    10 @CSCAT@ 0. // Requires NSCAT (10/20) and CSCAT (in units of cm).
+CSCAT    @NSCAT@ @CSCAT@ 0. // Requires NSCAT (10/20) and CSCAT (in units of cm).
 *
 *
 *
@@ -90,7 +90,7 @@ TELESCOPE             -29.456E2   -31.295E2   1.42E2        10.00E2   # MAGIC-02
 *
 FIXHEI  0.  0          // First interaction height & target (0. 0 for random)
 FIXCHI  0.             // Starting altitude (g/cm**2). 0. is at boundary to space.
-TSTART  T              // Needed for emission and scattering of primary
+* TSTART  T              // Needed for emission and scattering of primary
 ECUTS   0.3  0.1  0.020  0.020         // Energy cuts for particles
 MUADDI  F                              // Additional info for muons not needed
 MUMULT  T                              // Muon multiple scattering angle

--- a/config_LST1_2MAGIC_point_gammas.cfg
+++ b/config_LST1_2MAGIC_point_gammas.cfg
@@ -76,7 +76,7 @@ ARRANG -4.84             // La Palma, 01/12/2021
 * 
 * [ Core range ]
 *
-CSCAT    10 @CSCAT@ 0. // Requires NSCAT (10/20) and CSCAT (in units of cm).
+CSCAT    @NSCAT@ @CSCAT@ 0. // Requires NSCAT (10/20) and CSCAT (in units of cm).
 *
 *
 *
@@ -90,7 +90,7 @@ TELESCOPE             -29.456E2   -31.295E2   1.42E2        10.00E2   # MAGIC-02
 *
 FIXHEI  0.  0          // First interaction height & target (0. 0 for random)
 FIXCHI  0.             // Starting altitude (g/cm**2). 0. is at boundary to space.
-TSTART  T              // Needed for emission and scattering of primary
+* TSTART  T              // Needed for emission and scattering of primary
 ECUTS   0.3  0.1  0.020  0.020         // Energy cuts for particles
 MUADDI  F                              // Additional info for muons not needed
 MUMULT  T                              // Muon multiple scattering angle

--- a/config_LST1_2MAGIC_protons.cfg
+++ b/config_LST1_2MAGIC_protons.cfg
@@ -76,7 +76,7 @@ ARRANG -4.84             // La Palma, 01/12/2021
 * 
 * [ Core range ]
 *
-CSCAT    10 @CSCAT@ 0. // Requires NSCAT (10/20) and CSCAT (in units of cm).
+CSCAT    @NSCAT@ @CSCAT@ 0. // Requires NSCAT (10/20) and CSCAT (in units of cm).
 *
 *
 *
@@ -90,7 +90,7 @@ TELESCOPE             -29.456E2   -31.295E2   1.42E2        10.00E2   # MAGIC-02
 *
 FIXHEI  0.  0          // First interaction height & target (0. 0 for random)
 FIXCHI  0.             // Starting altitude (g/cm**2). 0. is at boundary to space.
-TSTART  T              // Needed for emission and scattering of primary
+* TSTART  T              // Needed for emission and scattering of primary
 ECUTS   0.3  0.1  0.020  0.020         // Energy cuts for particles
 MUADDI  F                              // Additional info for muons not needed
 MUMULT  T                              // Muon multiple scattering angle

--- a/config_LST1_muons.cfg
+++ b/config_LST1_muons.cfg
@@ -84,7 +84,7 @@ TELESCOPE 0.0E2    0.0E2  16.00E2    12.50E2  // LST
 
 * [Interaction flags]
 FIXHEI  0.  0          // First interaction height & target (0. 0 for random)
-TSTART  T              // Needed for emission and scattering of primary
+* TSTART  T              // Needed for emission and scattering of primary
 ECUTS   0.3  0.1  0.020  0.020         // Energy cuts for particles
 MUADDI  F                              // Additional info for muons not needed
 MUMULT  T                              // Muon multiple scattering angle


### PR DESCRIPTION
…teerable par.
This pull request modifies the configuration files in order to be compatible with Corsika when is compiled with CURVED option enabled. CURVED is not supporting the TSTART handle. It is always set in true value (as we want). Removing the keyword doesn't affect simulations performed with Corsika when CURVED is not enabled, since in IACT option, TSTART is set to true by default. So it is redundant.

Once the request is approved we can move on with zd > 70deg nodes.