### PR TITLE
revert changes on MAGIC focal length

### DIFF
--- a/MAGIC1.cfg
+++ b/MAGIC1.cfg
@@ -23,10 +23,10 @@ photon_delay = 13    % ns
 % ------------------------- Optical parameters --------------------------
 
 parabolic_dish      = 1        % Intermediate shape (mirrors on parabolic dish).
-focal_length        = 1700.     % Focal length for camera.
+focal_length        = 1697.    % Focal length for camera.
 effective_focal_length = 1821.2 % corrected for 1.0713 aberration 
 mirror_focal_length = 0        % Adapted automatically unless specified in file
-dish_shape_length   = 1700   % If using a single fixed focal length for a genuine parabolic dish
+dish_shape_length   = 1697.   % If using a single fixed focal length for a genuine parabolic dish
 
 #ifdef PERFECT_DISH
   % If all mirrors are just perfect:
@@ -47,7 +47,7 @@ dish_shape_length   = 1700   % If using a single fixed focal length for a genuin
 
 mirror_list         = mirror_CTA-MAGIC1_new_corrected-mirror-positions.dat  % with individual MAGIC mirror tiles flen; should be around 230 m^2 in total
 mirror_offset       = 0.       % 0.: Axes crossing at dish center.
-focus_offset        = 2.89     % 1./(1./1700.-1./10.e5) - 1700. (focusing at 10 km distance from the telescope)
+focus_offset        = 3.     % focusing at ~10 km distance from the telescope
 
 mirror_reflectivity = ref_MAGIC1_average_20220201.dat % Recomputed average from MAGIC reflector
 telescope_transmission = 0.61  % camera "mirror fraction" for ST.03.16

--- a/MAGIC2.cfg
+++ b/MAGIC2.cfg
@@ -23,10 +23,10 @@ photon_delay = 13    % ns
 % ------------------------- Optical parameters --------------------------
 
 parabolic_dish      = 1        % Intermediate shape (mirrors on parabolic dish).
-focal_length        = 1700     % Focal length for camera.
+focal_length        = 1697.     % Focal length for camera.
 effective_focal_length = 1821.2 % corrected for 1.0713 aberration 
 mirror_focal_length = 0        % Adapted automatically unless specified in file
-dish_shape_length   = 1700   % If using a single fixed focal length for a genuine parabolic dish
+dish_shape_length   = 1697.    % If using a single fixed focal length for a genuine parabolic dish
 
 #ifdef PERFECT_DISH
   % If all mirrors are just perfect:
@@ -46,7 +46,7 @@ dish_shape_length   = 1700   % If using a single fixed focal length for a genuin
 
 mirror_list         = mirror_CTA-MAGIC2_new_corrected-mirror-positions.dat  % with individual MAGIC mirror tiles flen; should be around 230 m^2 in total
 mirror_offset       = 0.       % 0.: Axes crossing at dish center.
-focus_offset        = 2.89     % 1./(1./1700.-1./10.e5) - 1700. (focusing at 10 km distance from the telescope)
+focus_offset        = 3.     % focusing at ~10 km distance from the telescope
 
 mirror_reflectivity = ref_MAGIC2_average.dat % MAGIC reflector weighted average reflectivity
 telescope_transmission = 0.69  % camera "mirror fraction" for ST.03.16


### PR DESCRIPTION
following discussion in Issue #47  the focal length and dish shape length were reverted to 1697 cm, and focus offset to 3 cm.
Effective focal length kept as it is